### PR TITLE
Add basic income/expense tracking script

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,22 @@
 - 💞️ I’m looking to collaborate on Apps and Webseites
 - 📫 How to reach me contact me on Github or https://twitter.com/marhol8
 
-<!---
-marhol8/marhol8 is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
-You can click the Preview link to take a look at your changes.
---->
+## Simple income and expense tracker
+
+This repository contains a small Python script `expense_tracker.py` that lets you collect and summarize your income and expenses. Transactions are stored locally in `data.json`.
+
+### Usage
+
+Add a new income or expense:
+
+```bash
+python expense_tracker.py add --type income --amount 1000 --description "Salary"
+python expense_tracker.py add --type expense --amount 50 --description "Groceries"
+```
+
+Show a summary of all transactions:
+
+```bash
+python expense_tracker.py summary
+```
+

--- a/expense_tracker.py
+++ b/expense_tracker.py
@@ -1,0 +1,52 @@
+import argparse
+import json
+from pathlib import Path
+
+DATA_FILE = Path('data.json')
+
+def load_data():
+    if DATA_FILE.exists():
+        with open(DATA_FILE, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    return []
+
+def save_data(data):
+    with open(DATA_FILE, 'w', encoding='utf-8') as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+def add_transaction(tr_type, amount, description):
+    data = load_data()
+    data.append({'type': tr_type, 'amount': amount, 'description': description})
+    save_data(data)
+
+def show_summary():
+    data = load_data()
+    income = sum(item['amount'] for item in data if item['type'] == 'income')
+    expense = sum(item['amount'] for item in data if item['type'] == 'expense')
+    balance = income - expense
+    print(f"Total income: {income:.2f}")
+    print(f"Total expenses: {expense:.2f}")
+    print(f"Balance: {balance:.2f}")
+
+def main():
+    parser = argparse.ArgumentParser(description='Simple income and expense tracker')
+    subparsers = parser.add_subparsers(dest='command')
+
+    add_parser = subparsers.add_parser('add', help='Add a new transaction')
+    add_parser.add_argument('--type', choices=['income', 'expense'], required=True, help='Transaction type')
+    add_parser.add_argument('--amount', type=float, required=True, help='Amount of the transaction')
+    add_parser.add_argument('--description', default='', help='Optional description')
+
+    subparsers.add_parser('summary', help='Show income and expense summary')
+
+    args = parser.parse_args()
+
+    if args.command == 'add':
+        add_transaction(args.type, args.amount, args.description)
+    elif args.command == 'summary':
+        show_summary()
+    else:
+        parser.print_help()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a simple Python CLI for tracking income and expenses
- document usage in README

## Testing
- `python expense_tracker.py summary`
- `python expense_tracker.py add --type income --amount 100 --description "Test income"`
- `python expense_tracker.py summary`


------
https://chatgpt.com/codex/tasks/task_e_685c35fe696c83209a82b3eb87167e4a